### PR TITLE
add clarification to worker.disconnect()

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -291,7 +291,8 @@ automatically closed by workers, and disconnect does not wait for them to close
 before exiting.
 
 In a worker, `process.disconnect` exists, but it is not this function;
-it is [`disconnect()`][].
+it is [`disconnect()`][]. Because [`disconnect()`][] does not set
+`.exitedAfterDisconnect`, the worker calls `process.exit(0)`.
 
 Because long living server connections may block workers from disconnecting, it
 may be useful to send a message, so application specific actions may be taken to


### PR DESCRIPTION
There has been some confusion on the usage of process.disconnect() from within workers. I'm not 100% sure what the copy should be, but this diff contains my stab at it. I welcome alternative phrasings.

The documentation on worker.process states the outcome of existedAfterDisconnect not being true when calling process.disconnect(). Moving the effect closer to the disambiguation between disconnect functions may reduce the confusion.

Fixes: https://github.com/nodejs/node/issues/13671
Fixes: https://github.com/nodejs/node/issues/27679
Refs: https://nodejs.org/api/cluster.html#cluster_worker_process